### PR TITLE
fix: allow missing "rp" field in exn message from pre 1.1.25 KERIpy

### DIFF
--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -2154,6 +2154,17 @@ def test_serderkeri_bar():
 
     """End Test"""
 
+def test_serderkeri_exn_old():
+    """Test SerderKERI exn msg"""
+    serder = SerderKERI(raw=b'{"v":"KERI10JSON000088_","t":"exn",'
+                   b'"d":"EMuAoRSE4zREKKYyvuNeYCDM9_MwPQIh1WL0'
+                   b'cFC4e-bU","i":"","p":"","dt":"","r":"","q":{},"a":[],"e":{}}', ilk=kering.Ilks.exn)
+
+    assert serder.verify()  # because pre is empty
+    assert serder.ilk == kering.Ilks.exn
+    assert serder.pre == ''
+    assert serder.prior == ''
+
 def test_serderkeri_exn():
     """Test SerderKERI exn msg"""
 


### PR DESCRIPTION
Older versions of KERIpy do not have the "rp" field in their Exchange (exn) message body at the top level. As of version 1.1.25, about June 12th 2024, the "rp" message was added for message routing, which was a backwards incompatible change since the parser was not updated to support a new protocol version for the new exn message version. This PR is a temporary workaround for this incompatibility. The plan is to tell people to move off of 1.1.x versions as soon as possible.