### PR TITLE
feat: configure LMDB db sizes in config file

### DIFF
--- a/scripts/keri/cf/main/wan.json
+++ b/scripts/keri/cf/main/wan.json
@@ -1,5 +1,25 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wan": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5632/", "http://127.0.0.1:5642/"]

--- a/scripts/keri/cf/main/wes.json
+++ b/scripts/keri/cf/main/wes.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wes": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5634/", "http://127.0.0.1:5644/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wil.json
+++ b/scripts/keri/cf/main/wil.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wil": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5633/", "http://127.0.0.1:5643/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wit.json
+++ b/scripts/keri/cf/main/wit.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wit": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5635/", "http://127.0.0.1:5645/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wub.json
+++ b/scripts/keri/cf/main/wub.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wub": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5636/", "http://127.0.0.1:5646/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wyz.json
+++ b/scripts/keri/cf/main/wyz.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wyz": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5637/", "http://127.0.0.1:5647/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/src/keri/app/cli/commands/escrow.py
+++ b/src/keri/app/cli/commands/escrow.py
@@ -49,7 +49,7 @@ def escrows(tymth, tock=0.0, **opts):
 
     try:
         with existing.existingHby(name=name, base=base, bran=bran) as hby:
-            reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
+            reger = viring.Reger(name=hby.name, db=hby.db, temp=False, cf=hby.cf)
 
             escrows = dict()
             if (not escrow) or escrow == "out-of-order-events":

--- a/src/keri/app/cli/commands/escrow/clear.py
+++ b/src/keri/app/cli/commands/escrow/clear.py
@@ -51,5 +51,5 @@ def clear(tymth, tock=0.0, **opts):
 
     with existing.existingHby(name=name, base=base, bran=bran) as hby:
         hby.db.clearEscrows()
-        reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
+        reger = viring.Reger(name=hby.name, db=hby.db, temp=False, cf=hby.cf)
         reger.clearEscrows()

--- a/src/keri/app/cli/commands/escrow/list.py
+++ b/src/keri/app/cli/commands/escrow/list.py
@@ -49,7 +49,7 @@ def escrows(tymth, tock=0.0, **opts):
 
     try:
         with existing.existingHby(name=name, base=base, bran=bran) as hby:
-            reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
+            reger = viring.Reger(name=hby.name, db=hby.db, temp=False, cf=hby.cf)
 
             escrows = dict()
             if (not escrow) or escrow == "out-of-order-events":

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -203,23 +203,27 @@ class Habery:
         self.base = base
         self.temp = temp
 
-        self.ks = ks if ks is not None else keeping.Keeper(name=self.name,
-                                                           base=self.base,
-                                                           temp=self.temp,
-                                                           reopen=True,
-                                                           clear=clear,
-                                                           headDirPath=headDirPath)
-        self.db = db if db is not None else basing.Baser(name=self.name,
-                                                         base=self.base,
-                                                         temp=self.temp,
-                                                         reopen=True,
-                                                         clear=clear,
-                                                         headDirPath=headDirPath)
         self.cf = cf if cf is not None else configing.Configer(name=self.name,
                                                                base=self.base,
                                                                temp=self.temp,
                                                                reopen=True,
                                                                clear=clear)
+        logger.info("[%s] Habery config file %s at %s", self.name, self.cf.name, self.cf.path)
+
+        self.ks = ks if ks is not None else keeping.Keeper(name=self.name,
+                                                           base=self.base,
+                                                           temp=self.temp,
+                                                           reopen=True,
+                                                           clear=clear,
+                                                           headDirPath=headDirPath,
+                                                           cf=cf)
+        self.db = db if db is not None else basing.Baser(name=self.name,
+                                                         base=self.base,
+                                                         temp=self.temp,
+                                                         reopen=True,
+                                                         clear=clear,
+                                                         headDirPath=headDirPath,
+                                                         cf=cf)
 
         self.mgr = None  # wait to setup until after ks is known to be opened
         self.rtr = routing.Router()

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -50,10 +50,10 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     if hab is None:
         hab = hby.makeHab(name=alias, transferable=False)
 
-    reger = viring.Reger(name=hab.name, db=hab.db, temp=False)
+    reger = viring.Reger(name=hab.name, db=hab.db, temp=False, cf=hby.cf)
     verfer = verifying.Verifier(hby=hby, reger=reger)
 
-    mbx = mbx if mbx is not None else storing.Mailboxer(name=alias, temp=hby.temp)
+    mbx = mbx if mbx is not None else storing.Mailboxer(name=alias, temp=hby.temp, cf=hby.cf)
     forwarder = forwarding.ForwardHandler(hby=hby, mbx=mbx)
     exchanger = exchanging.Exchanger(hby=hby, handlers=[forwarder])
     clienter = httping.Clienter()
@@ -1192,7 +1192,7 @@ class QueryEnd:
 
     def __init__(self, hab):
         self.hab = hab
-        self.reger = viring.Reger(name=hab.name, db=hab.db, temp=False)
+        self.reger = viring.Reger(name=hab.name, db=hab.db, temp=False, cf=hab.cf)
    
     def on_get(self, req, rep):
         """ Handles GET requests to query KEL or TEL events of a pre from a witness.

--- a/src/keri/app/notifying.py
+++ b/src/keri/app/notifying.py
@@ -8,7 +8,6 @@ from collections.abc import Iterable
 from typing import Union, Type
 
 from keri import kering, help
-from keri.db.basing import KERIBaserMapSizeKey
 from keri.help import helping
 from keri.app import signaling
 from keri.core import coring
@@ -201,9 +200,6 @@ class DicterSuber(subing.Suber):
         """
         return self.db.cnt(db=self.sdb)
 
-# Env var for configuring LMDB size for the Noter database
-KERINoterMapSizeKey = "KERI_NOTER_MAP_SIZE"
-
 
 class Noter(dbing.LMDBer):
     """
@@ -214,40 +210,35 @@ class Noter(dbing.LMDBer):
     TailDirPath = "keri/not"
     AltTailDirPath = ".keri/not"
     TempPrefix = "keri_not_"
+    ConfigKey = "noter"
 
     def __init__(self, name="not", headDirPath=None, reopen=True, **kwa):
         """
+        Sets up a named notification database where all notifications for a controller are stored.
 
         Parameters:
-            headDirPath:
-            perm:
-            reopen:
-            kwa:
+            headDirPath(str): optional str head directory pathname for main database
+                If not provided use default .HeadDirpath
+            perm(int): is numeric os permissions for directory and/or file(s)
+            reopen(bool): True means database will be reopened by this init
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
+            kwa: pass through init args to reopen and LMDBer
         """
         self.notes = None
         self.nidx = None
         self.ncigs = None
 
-        # support separate mailbox size config yet fall back to baser size if not set
-        noterSize = os.getenv(KERINoterMapSizeKey, None)
-        baserSize = os.getenv(KERIBaserMapSizeKey, None)
-        mapSize = noterSize if (noterSize is not None and noterSize != '') else baserSize
-        if mapSize:
-            try:
-                self.MapSize = int(mapSize)
-            except ValueError:
-                logger.error("KERI_NOTER_MAP_SIZE and KERI_BASER_MAP_SIZE must be an integer value >1!")
-                raise
-
         super(Noter, self).__init__(name=name, headDirPath=headDirPath, reopen=reopen, **kwa)
 
     def reopen(self, **kwa):
         """
+        Sets up specific named LMDB sub databases to be opened.
 
-        :param kwa:
+        :param kwa: pass through init args to reopen and LMDBer
         :return:
         """
         super(Noter, self).reopen(**kwa)
+        logger.info("[%s] Noter map size set to %s", self.name, self.mapSize)
 
         self.notes = DicterSuber(db=self, subkey='nots.', sep='/', klas=Notice)
         self.nidx = subing.Suber(db=self, subkey='nidx.')

--- a/src/keri/app/notifying.py
+++ b/src/keri/app/notifying.py
@@ -382,7 +382,7 @@ class Notifier:
         """
         self.hby = hby
         self.signaler = signaler if signaler is not None else signaling.Signaler()
-        self.noter = noter if noter is not None else Noter(name=hby.name, temp=hby.temp)
+        self.noter = noter if noter is not None else Noter(name=hby.name, temp=hby.temp, cf=hby.cf)
 
     def add(self, attrs):
         """  Add unread notice to the end of the current list of notices

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -184,7 +184,7 @@ class Respondant(doing.DoDoer):
 
         self.hby = hby
         self.aids = aids
-        self.mbx = mbx if mbx is not None else Mailboxer(name=self.hby.name)
+        self.mbx = mbx if mbx is not None else Mailboxer(name=self.hby.name, cf=hby.cf)
         self.postman = forwarding.Poster(hby=self.hby, mbx=self.mbx)
 
         doers = [self.postman, doing.doify(self.responseDo), doing.doify(self.cueDo)]

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -37,11 +37,8 @@ from hio.base import doing
 
 import keri
 from . import dbing, koming, subing
-from .. import kering
-from .. import core
+from .. import kering,core, help
 from ..core import coring, eventing, parsing, serdering, indexing
-
-from .. import help
 from ..help import helping
 
 
@@ -943,6 +940,7 @@ class Baser(dbing.LMDBer):
         kevers (dbdict): read through cache of kevers of states for KELs in db
 
     """
+    ConfigKey = "baser"
 
     def __init__(self, headDirPath=None, reopen=False, **kwa):
         """
@@ -959,14 +957,14 @@ class Baser(dbing.LMDBer):
                 If not provided use default .HeadDirpath
             mode is int numeric os dir permissions for database directory
             reopen (bool): True means database will be reopened by this init
-
-
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
         """
         self.prefixes = oset()  # should change to hids for hab ids
         self.groups = oset()  # group hab ids
         self._kevers = dbdict()
         self._kevers.db = self  # assign db for read through cache of kevers
 
+        # Alternate way to set map size by environment variable
         if (mapSize := os.getenv(KERIBaserMapSizeKey)) is not None:
             try:
                 self.MapSize = int(mapSize)
@@ -1000,6 +998,7 @@ class Baser(dbing.LMDBer):
 
         """
         super(Baser, self).reopen(**kwa)
+        logger.debug("[%s] Baser map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -998,7 +998,7 @@ class Baser(dbing.LMDBer):
 
         """
         super(Baser, self).reopen(**kwa)
-        logger.debug("[%s] Baser map size set to %s", self.name, self.mapSize)
+        logger.info("[%s] Baser map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character
@@ -1367,7 +1367,7 @@ class Baser(dbing.LMDBer):
                 mod = importlib.import_module(modName)
                 try:
                     print(f"running migration {modName}")
-                    mod.migrate(self)
+                    mod.migrate(self, self.cf)
                 except Exception as e:
                     print(f"\nAbandoning migration {migration} at version {version} with error: {e}")
                     return

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -313,6 +313,7 @@ class LMDBer(filing.Filer):
     Attributes:
         env (lmdb.env): LMDB main (super) database environment
         readonly (bool): True means open LMDB env as readonly
+        cf (Configer): optional Configer to configure the opened LMDB database
 
     Properties:
 
@@ -340,7 +341,7 @@ class LMDBer(filing.Filer):
     TempSuffix = "_test"
     Perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o1700==960
     MaxNamedDBs = 96
-    MapSize = 104857600
+    ConfigKey = 'lmdber'
 
     def __init__(self, readonly=False, **kwa):
         """
@@ -376,18 +377,20 @@ class LMDBer(filing.Filer):
 
             readonly (bool): True means open database in readonly mode
                                 False means open database in read/write mode
-
+            cf (Configer): optional Configer to configure the opened LMDB database
         """
 
         self.env = None
         self._version = None
         self.readonly = True if readonly else False
+        self._mapSize = 104_857_600  # 10MB fallback default
+        self.cf = kwa["cf"] if "cf" in kwa else None
         super(LMDBer, self).__init__(**kwa)
 
     def reopen(self, readonly=False, **kwa):
         """
         Open if closed or close and reopen if opened or create and open if not
-        if not preexistent, directory path for lmdb at .path and then
+        preexistent, directory path for lmdb at .path and then
         Open lmdb and assign to .env
 
         Parameters:
@@ -408,15 +411,21 @@ class LMDBer(filing.Filer):
             fext (str): File extension when .filed
             readonly (bool): True means open database in readonly mode
                                 False means open database in read/write mode
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
         """
         exists = self.exists(name=self.name, base=self.base)
         opened = super(LMDBer, self).reopen(**kwa)
         if readonly is not None:
             self.readonly = readonly
 
+        config = self.cf.get() if self.cf is not None else None
+        lmdberConf = config.get(self.ConfigKey, None) if config is not None else None
+        if lmdberConf is not None:
+            self.mapSize = lmdberConf.get("mapSize", 104_857_600)  # 10MB default
+
         # open lmdb major database instance
         # creates files data.mdb and lock.mdb in .dbDirPath
-        self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=self.MapSize,
+        self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=self.mapSize,
                              mode=self.perm, readonly=self.readonly)
 
         self.opened = True if opened and self.env else False
@@ -454,6 +463,34 @@ class LMDBer(filing.Filer):
 
         self._version = val
         self.setVer(self._version)
+
+    @property
+    def mapSize(self):
+        """
+        Get LMDB map size (database file size) limit for this instance.
+        Returns:
+            int: the map size limit for this instance
+        """
+        if self._mapSize is None:
+            self._mapSize = 104_857_600  # 512MB fallback default
+        return self._mapSize
+
+    @mapSize.setter
+    def mapSize(self, val):
+        """
+        Set LMDB map size (database file size) limit for this instance.
+        Parameters:
+            val (int): the new map size limit for this instance
+        """
+        if val is None:
+            raise ValueError(f"Invalid map size {val=}. Must be positive integer.")
+        try:
+            val = int(val)
+        except ValueError:
+            raise ValueError(f"Invalid map size {val=}. Must be positive integer.")
+        if val <= 0:
+            raise ValueError(f"Invalid map size {val=}. Must be positive integer.")
+        self._mapSize = val
 
     def close(self, clear=False):
         """

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -343,7 +343,7 @@ class LMDBer(filing.Filer):
     MaxNamedDBs = 96
     ConfigKey = 'lmdber'
 
-    def __init__(self, readonly=False, **kwa):
+    def __init__(self, readonly=False, cf=None, **kwa):
         """
         Setup main database directory at .dirpath.
         Create main database environment at .env using .path.
@@ -384,10 +384,10 @@ class LMDBer(filing.Filer):
         self._version = None
         self.readonly = True if readonly else False
         self._mapSize = 104_857_600  # 10MB fallback default
-        self.cf = kwa["cf"] if "cf" in kwa else None
+        self.cf = cf
         super(LMDBer, self).__init__(**kwa)
 
-    def reopen(self, readonly=False, **kwa):
+    def reopen(self, readonly=False, cf=None, **kwa):
         """
         Open if closed or close and reopen if opened or create and open if not
         preexistent, directory path for lmdb at .path and then
@@ -418,9 +418,13 @@ class LMDBer(filing.Filer):
         if readonly is not None:
             self.readonly = readonly
 
-        config = self.cf.get() if self.cf is not None else None
-        lmdberConf = config.get(self.ConfigKey, None) if config is not None else None
-        if lmdberConf is not None:
+        cf = cf if cf is not None else self.cf
+        config = cf.get() if cf is not None else None
+        lmdberConf = config.get(LMDBer.ConfigKey) if config is not None else None
+        dbconf = config.get(self.ConfigKey, None) if config is not None else None
+        if dbconf is not None:
+            self.mapSize = dbconf.get("mapSize", 104_857_600)  # 10MB default
+        elif config and lmdberConf: # fall back to LMDBer size if present
             self.mapSize = lmdberConf.get("mapSize", 104_857_600)  # 10MB default
 
         # open lmdb major database instance

--- a/src/keri/db/migrations/add_key_and_reg_state_schemas.py
+++ b/src/keri/db/migrations/add_key_and_reg_state_schemas.py
@@ -20,7 +20,7 @@ def _check_if_needed(db):
         return False
     return True
 
-def migrate(db):
+def migrate(db, cf=None):
     """Adds schema for KeyStateRecord, RegStateRecord, and migrates the rgy.cancs., hby.db.pubs.,
     and hby.db.digs. to be up to date as of 2022-??-??
     This migration performs the following:
@@ -75,7 +75,7 @@ def migrate(db):
 
             nstates.pin(keys=keys, val=ksr)
 
-        rgy = viring.Reger(name=db.name, base=db.base, db=db, temp=db.temp, reopen=True)
+        rgy = viring.Reger(name=db.name, base=db.base, db=db, temp=db.temp, reopen=True, cf=cf)
 
         rstates = koming.Komer(db=rgy,
                                schema=dict,

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -38,7 +38,7 @@ class Regery:
         self.cues = cues if cues is not None else decking.Deck()
 
         self.reger = reger if reger is not None else Reger(name=self.name, base=base, db=self.hby.db, temp=temp,
-                                                           reopen=True)
+                                                           reopen=True, cf=hby.cf)
         self.tvy = eventing.Tevery(reger=self.reger, db=self.hby.db, local=True, lax=True)
         self.psr = parsing.Parser(framed=True, kvy=self.hby.kvy, tvy=self.tvy)
 

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -693,7 +693,7 @@ class Tever:
         if not (rsr or serder):
             raise ValueError("Missing required arguments. Need state or serder")
 
-        self.reger = reger if reger is not None else viring.Reger()
+        self.reger = reger if reger is not None else viring.Reger(cf=db.cf if db else None)
         self.cues = cues if cues is not None else decking.Deck()
 
         self.db = db if db is not None else basing.Baser(reopen=True)
@@ -1482,7 +1482,7 @@ class Tevery:
         """
         self.db = db if db is not None else basing.Baser(reopen=True)  # default name = "main"
         self.rvy = rvy
-        self.reger = reger if reger is not None else viring.Reger()
+        self.reger = reger if reger is not None else viring.Reger(cf=db.cf if db else None)
         self.local = True if local else False  # local vs nonlocal restrictions
         self.lax = True if lax else False
         self.cues = cues if cues is not None else decking.Deck()

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -42,7 +42,7 @@ class Verifier:
 
         """
         self.hby = hby
-        self.reger = reger if reger is not None else Reger(name=self.hby.name, temp=self.hby.temp)
+        self.reger = reger if reger is not None else Reger(name=self.hby.name, temp=self.hby.temp, cf=self.hby.cf)
         self.creds = creds if creds is not None else decking.Deck()  # subclass of deque
         self.cues = cues if cues is not None else decking.Deck()  # subclass of deque
         self.CredentialExpiry = expiry

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -171,9 +171,6 @@ def openReger(name="test", **kwa):
     """
     return dbing.openLMDB(cls=Reger, name=name, **kwa)
 
-# Env var for configuring LMDB size for the Keeper database
-KERIRegerMapSizeKey = "KERI_REGER_MAP_SIZE"
-
 
 class Reger(dbing.LMDBer):
     """ Reger sets up named sub databases for TEL registry
@@ -242,6 +239,7 @@ class Reger(dbing.LMDBer):
     TailDirPath = "keri/reg"
     AltTailDirPath = ".keri/reg"
     TempPrefix = "keri_reg_"
+    ConfigKey = "reger"
 
     def __init__(self, headDirPath=None, reopen=True, **kwa):
         """
@@ -258,6 +256,7 @@ class Reger(dbing.LMDBer):
                 If not provided use default .HeadDirpath
             mode (int): numeric os dir permissions for database directory
             reopen (boolean,): IF True then database will be reopened by this init
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
 
         Notes:
 
@@ -280,17 +279,6 @@ class Reger(dbing.LMDBer):
         else:
             self._tevers = dict()
 
-        # support separate Reger size config yet fall back to baser size if not set
-        regerSize = os.getenv(KERIRegerMapSizeKey, None)
-        baserSize = os.getenv(KERIBaserMapSizeKey, None)
-        mapSize = regerSize if (regerSize is not None and regerSize != '') else baserSize
-        if mapSize:
-            try:
-                self.MapSize = int(mapSize)
-            except ValueError:
-                logger.error("KERI_REGER_MAP_SIZE and KERI_BASER_MAP_SIZE must be an integer value >1!")
-                raise
-
         super(Reger, self).__init__(headDirPath=headDirPath, reopen=reopen, **kwa)
 
 
@@ -309,6 +297,7 @@ class Reger(dbing.LMDBer):
 
         """
         super(Reger, self).reopen(**kwa)
+        logger.info("[%s] Reger map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -3,17 +3,12 @@
 tests.app.test_multisig module
 
 """
-import datetime
-import os
-
 import pytest
 
-from keri.app import notifying, habbing
-from keri.app.notifying import Noter, KERINoterMapSizeKey
+from keri.app import notifying, habbing, configing
+from keri.app.notifying import Noter
 from keri.core import coring
 from keri.db import dbing
-from keri.db.basing import KERIBaserMapSizeKey
-from keri.db.dbing import LMDBer
 from keri.help import helping
 
 
@@ -226,37 +221,15 @@ def test_notifier(mockHelpingNowUTC):
     assert notifier.mar(note.rid) is False
     assert notifier.rem(note.rid) is True
 
-def test_noter_db_size_set_from_env_var():
-    # Clear environment before test
-    if KERIBaserMapSizeKey in os.environ:
-        os.environ.pop(KERIBaserMapSizeKey)
-    if KERINoterMapSizeKey in os.environ:
-        os.environ.pop(KERINoterMapSizeKey)
 
-    new_map_size = 10737418240
-    # Default map size works
-    noter = Noter()
-    assert noter.env.info()['map_size'] != new_map_size, "Expected map size to be the default 10MB"
-    assert noter.env.info()['map_size'] == LMDBer.MapSize, "Expected map size to be the default 10MB"
+def test_noter_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        noter=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
 
-    # Specific map size works
-    os.environ[KERINoterMapSizeKey] = f"{new_map_size}"
-
-    noter = Noter()
-    assert noter.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
-    os.environ.pop(KERINoterMapSizeKey)
-
-    # generic map size works
-    baser_map_size = 10737418240
-    os.environ[KERIBaserMapSizeKey] = f"{baser_map_size}"
-
-    noter = Noter()
-    assert noter.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
-
-    # bad map size throws
-    os.environ[KERINoterMapSizeKey] = f"bad_map_size"
-    with pytest.raises(ValueError) as excinfo:
-        Noter()
-    assert "invalid literal for int" in str(excinfo.value), "Expected ValueError when map size is not an integer"
-    os.environ.pop(KERIBaserMapSizeKey)
-    os.environ.pop(KERINoterMapSizeKey)
+    noter = Noter(reopen=True,cf=cf)  # default is to not reopen
+    assert noter.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -12,7 +12,7 @@ import pytest
 import lmdb
 from hio.base import doing
 from keri import core
-from keri.app import habbing
+from keri.app import habbing, configing
 from keri.core import coring, eventing, serdering
 from keri.core.coring import Kinds, versify, Seqner
 from keri.core.eventing import incept, rotate, interact, Kever
@@ -1906,6 +1906,20 @@ def test_clear_escrows():
         assert db.udes.cntAll() == 0
         assert db.epsd.cntAll() == 0
         assert db.dpub.cntAll() == 0
+
+
+def test_baser_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        baser=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    baser = Baser(reopen=True,cf=cf)  # default is to not reopen
+    assert baser.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
+
 
 if __name__ == "__main__":
     test_baser()

--- a/tests/db/test_dbing.py
+++ b/tests/db/test_dbing.py
@@ -6,18 +6,15 @@ tests.db.dbing module
 import pytest
 
 import os
-import json
-import datetime
 
 import lmdb
 from  ordered_set import OrderedSet as oset
 
-from hio.base import doing
-
+from keri.app import configing
 from keri.db import dbing
-from keri.db.dbing import clearDatabaserDir, openLMDB
-from keri.db.dbing import (dgKey, onKey, fnKey, snKey, dtKey, splitKey,
-                           splitOnKey, splitKeyFN, splitSnKey, splitKeyDT)
+from keri.db.dbing import openLMDB
+from keri.db.dbing import (dgKey, onKey, snKey, dtKey, splitKey,
+                           splitOnKey, splitSnKey, splitKeyDT)
 from keri.db.dbing import LMDBer
 
 
@@ -1152,6 +1149,46 @@ def test_lmdber():
     assert not os.path.exists(dber.path)
 
     """ End Test """
+
+
+def test_lmdber_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        lmdber=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    databaser = LMDBer(cf=cf)
+    assert databaser.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
+
+    badConfigStr = dict(
+        lmdber=dict(
+            mapSize="somestr"
+        )
+    )
+    cf.put(badConfigStr)
+    with pytest.raises(ValueError):
+        LMDBer(cf=cf)
+
+    badConfigNone = dict(
+        lmdber=dict(
+            mapSize=None
+        )
+    )
+    cf.put(badConfigNone)
+    with pytest.raises(ValueError):
+        LMDBer(cf=cf)
+
+    badConfigNeg = dict(
+        lmdber=dict(
+            mapSize=-1
+        )
+    )
+    cf.put(badConfigNeg)
+    with pytest.raises(ValueError):
+        LMDBer(cf=cf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds ability to configure LMDB sizes using the bootstrap configuration file.
Also adds some INFO level logging on the config file location and database sizes set.

Adds the `.mapSize` property to LMDBer and the `LMDBer.ConfigKey` that is overridden in each subclass. This config key is used to select a subset of the overall config file to use to configure each LMDBer subclass.

For backwards compatibility the `KERI_BASER_MAP_SIZE` environment variable still works, yet may be deprecated in the future. Moving forward using the configuration file as the single source of truth for configuration is the recommended path.

The other GLEIF-IT/keripy specific environment variables have been removed in favor of the configuration file approach shown below.

There is both a global `lmdber` config block and the subclass specific blocks shown below illustrate how to configure map sizes either globally or per class.

```hjson
{
  "dt": "2022-01-20T12:57:59.823350+00:00",
  "lmdber": {
    // LMDB Map Size - 50 MB
    "mapSize": 52428800
  },
  "baser": {
    // LMDB Map size - 1 GB
    "mapSize": 1073741824
  },
  "keeper": {
    // LMDB Map Size - 25 MB
    "mapSize": 26214400
  },
  "mailboxer": {
    // LMDB Map Size - 16.384 GB
    "mapSize": 17179869184
  },
  "reger": {
    // LMDB Map Size - 512 MB
    "mapSize": 536870912
  },
  "noter": {
    // LMDB Map Size - 128 MB
    "mapSize": 134217728
  },
  "wan": {
    "dt": "2022-01-20T12:57:59.823350+00:00",
    "curls": ["tcp://127.0.0.1:5632/", "http://127.0.0.1:5642/"]
  },
  "iurls": [
  ]
}
```