### PR TITLE
Fix multisig delegation with type guard and widened prefix check

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -1701,8 +1701,7 @@ class Kever:
         Parameters:
             pre (str): qb64 identifier prefix if any.
         """
-        pre = pre if pre is not None else ""
-        return self.locallyOwned(pre=pre)
+        return pre in self.prefixes
 
 
     def locallyWitnessed(self, *, wits: list[str]=None, serder: (str)=None):
@@ -2388,7 +2387,7 @@ class Kever:
         # seal in this case can't be malicious since sourced locally.
         # Doesn't get to here until fully signed and witnessed.
 
-        if self.locallyDelegated(delpre) and not self.locallyOwned():  # local delegator
+        if serder.ilk in (Ilks.dip, Ilks.drt) and self.locallyDelegated(delpre) and not self.locallyOwned():  # local delegator of delegated event
             # must be local if locallyDelegated or caught above as misfit
             if delseqner is None or delsaider is None:  # missing delegation seal
                 # so escrow delegable. So local delegator can approve OOB.


### PR DESCRIPTION
These two fixes correct multisig delegation for the GLEIF-IT/keripy fork.