### PR TITLE
Fix multisig join by using the icp ked, not the exn ked

### DIFF
--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -187,7 +187,7 @@ class JoinDoer(doing.DoDoer):
 
         inits["toad"] = oicp.ked["bt"]
         inits["wits"] = oicp.ked["b"]
-        inits["delpre"] = oicp.ked["di"] if "di" in ked else None
+        inits["delpre"] = oicp.ked["di"] if "di" in oicp.ked else None
 
         print()
         print("Group Multisig Inception proposed:")


### PR DESCRIPTION
fix multisig join by using the icp ked, not the exn ked.

This is why multisig join failed and multisig operations had to replicate ops with the exact same command and the timestamp arg.