### PR TITLE
fix: delegator seal storage; test temp=True fix for cf

### DIFF
--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -94,6 +94,14 @@ class ConfirmDoer(doing.DoDoer):
         self.auto = auto
         super(ConfirmDoer, self).__init__(doers=doers)
 
+    def _addAuthorizerSeal(self, pre, edig, anchorSn, anchorSaid):
+        """Save the authorizer (delegator) event seal of the anchoring IXN event for an approved delegation."""
+        dgkey = dbing.dgKey(pre, edig)
+        seqner = coring.Seqner(sn=anchorSn)
+        saider = coring.Saider(qb64=anchorSaid)
+        couple = seqner.qb64b + saider.qb64b
+        self.hby.db.setAes(dgkey, couple)
+
     def confirmDo(self, tymth, tock=0.0):
         """
         Parameters:
@@ -175,6 +183,8 @@ class ConfirmDoer(doing.DoDoer):
 
                         print(f"Delegate {eserder.pre} {typ} event committed.")
 
+                        self._addAuthorizerSeal(pre, edig, anchorSn=serder.sn, anchorSaid=serder.said)
+                        self.hby.kvy.processEscrowDelegables()  # removes DIP/DRT from delegables after adding it to kevers
                         self.remove(self.toRemove)
                         return True
 
@@ -231,7 +241,8 @@ class ConfirmDoer(doing.DoDoer):
 
                             print(f"Delegate {eserder.pre} {typ} event committed.")
 
-                        self.hby.db.delegables.rem(keys=(pre, sn))
+                        self._addAuthorizerSeal(pre, edig, anchorSn=hab.kever.sn, anchorSaid=hab.kever.serder.said)
+                        self.hby.kvy.processEscrowDelegables()  # removes DIP/DRT from delegables after adding it to kevers
                         self.remove(self.toRemove)
                         return True
 

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -102,7 +102,7 @@ def openHab(name="test", base="", salt=None, temp=True, cf=None, **kwa):
 
     with openHby(name=name, base=base, salt=salt, temp=temp, cf=cf) as hby:
         if (hab := hby.habByName(name)) is None:
-            hab = hby.makeHab(name=name, icount=1, isith='1', ncount=1, nsith='1', **kwa)
+            hab = hby.makeHab(name=name, icount=1, isith='1', ncount=1, nsith='1', cf=cf, **kwa)
 
         yield hby, hab
 


### PR DESCRIPTION
Adds the delegator AES seal storage from WebOfTrust/keripy v1.2.7
Adds the test fix for temp=True for configer (`cf`).